### PR TITLE
매물 계약 타입을 추가하고 준공일자 명칭을 명확하게 개선하라

### DIFF
--- a/src/docs/asciidoc/property-enums.adoc
+++ b/src/docs/asciidoc/property-enums.adoc
@@ -43,3 +43,19 @@
 |복층
 |===
 
+[[ContractType]]
+==== ContractType
+
+|===
+|필드 값 |설명
+
+|SALE
+|매매
+
+|LARGE_DEPOSIT
+|전세
+
+|MONTHLY_LEASE
+|월세
+|===
+

--- a/src/docs/asciidoc/property-enums.adoc
+++ b/src/docs/asciidoc/property-enums.adoc
@@ -52,7 +52,7 @@
 |SALE
 |매매
 
-|LARGE_DEPOSIT
+|JEONSE
 |전세
 
 |MONTHLY_LEASE

--- a/src/main/java/com/realestate/service/property/constant/ContractType.java
+++ b/src/main/java/com/realestate/service/property/constant/ContractType.java
@@ -11,7 +11,7 @@ public enum ContractType {
   /**
    * 전세.
    */
-  LARGE_DEPOSIT,
+  JEONSE,
   /**
    * 월세.
    */

--- a/src/main/java/com/realestate/service/property/constant/ContractType.java
+++ b/src/main/java/com/realestate/service/property/constant/ContractType.java
@@ -1,0 +1,20 @@
+package com.realestate.service.property.constant;
+
+/**
+ * 계약 타입을 관리합니다.
+ */
+public enum ContractType {
+  /**
+   * 매매.
+   */
+  SALE,
+  /**
+   * 전세.
+   */
+  LARGE_DEPOSIT,
+  /**
+   * 월세.
+   */
+  MONTHLY_LEASE,
+  ;
+}

--- a/src/main/java/com/realestate/service/property/constant/StructureType.java
+++ b/src/main/java/com/realestate/service/property/constant/StructureType.java
@@ -11,7 +11,7 @@ import lombok.RequiredArgsConstructor;
 public enum StructureType {
   ONE_ROOM("원룸"),
   TWO_ROOM("방 2개"),
-  TREE_ROOM("방 3개"),
+  THREE_ROOM("방 3개"),
   MORE_THAN_FOUR_ROOM("방 4개 이상"),
   DUPLEX("복층"),
   ;

--- a/src/main/java/com/realestate/service/property/dto/CreatePropertyCommand.java
+++ b/src/main/java/com/realestate/service/property/dto/CreatePropertyCommand.java
@@ -3,6 +3,7 @@ package com.realestate.service.property.dto;
 import java.time.LocalDate;
 
 import com.realestate.service.property.address.entity.PropertyAddress;
+import com.realestate.service.property.constant.ContractType;
 import com.realestate.service.property.constant.ResidentialType;
 import com.realestate.service.property.constant.StructureType;
 import com.realestate.service.property.entity.Property;
@@ -37,6 +38,7 @@ public class CreatePropertyCommand {
     private final String content;
     private final int area;
     private final StructureType structureType;
+    private final ContractType contractType;
     private final Long sellPrice;
     private final Long deposit;
     private final Integer monthlyPrice;
@@ -46,7 +48,7 @@ public class CreatePropertyCommand {
     private final int topFloor;
     private final Boolean availableParking;
     private final LocalDate moveInDate;
-    private final LocalDate estDate;
+    private final LocalDate completionDate;
 
     /**
      * PropertyInformationCommand 를 생성하여 리턴합니다.
@@ -56,6 +58,7 @@ public class CreatePropertyCommand {
                                       String content,
                                       int area,
                                       StructureType structureType,
+                                      ContractType contractType,
                                       Long sellPrice,
                                       Long deposit,
                                       Integer monthlyPrice,
@@ -65,11 +68,12 @@ public class CreatePropertyCommand {
                                       int topFloor,
                                       Boolean availableParking,
                                       LocalDate moveInDate,
-                                      LocalDate estDate) {
+                                      LocalDate completionDate) {
       this.title = title;
       this.content = content;
       this.area = area;
       this.structureType = structureType;
+      this.contractType = contractType;
       this.sellPrice = sellPrice;
       this.deposit = deposit;
       this.monthlyPrice = monthlyPrice;
@@ -79,7 +83,7 @@ public class CreatePropertyCommand {
       this.topFloor = topFloor;
       this.availableParking = availableParking;
       this.moveInDate = moveInDate;
-      this.estDate = estDate;
+      this.completionDate = completionDate;
     }
   }
 
@@ -144,9 +148,10 @@ public class CreatePropertyCommand {
         .propertyPrice(createPropertyPrice())
         .propertyFloor(createPropertyFloor())
         .structureType(propertyInformationCommand.getStructureType())
+        .contractType(propertyInformationCommand.getContractType())
         .availableParking(propertyInformationCommand.getAvailableParking())
         .moveInDate(propertyInformationCommand.getMoveInDate())
-        .estDate(propertyInformationCommand.getEstDate())
+        .completionDate(propertyInformationCommand.getCompletionDate())
         .area(propertyInformationCommand.getArea())
         .residentialType(propertyInformationCommand.getResidentialType())
         .build();

--- a/src/main/java/com/realestate/service/property/entity/PropertyInformation.java
+++ b/src/main/java/com/realestate/service/property/entity/PropertyInformation.java
@@ -8,6 +8,7 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 
 import com.realestate.service.common.converter.BooleanToNumberOneZeroTypeCodeConverter;
+import com.realestate.service.property.constant.ContractType;
 import com.realestate.service.property.constant.ResidentialType;
 import com.realestate.service.property.constant.StructureType;
 import lombok.AccessLevel;
@@ -29,6 +30,11 @@ public class PropertyInformation {
   @Enumerated(EnumType.STRING)
   private StructureType structureType;
   /**
+   * 거래 타입.
+   */
+  @Enumerated(EnumType.STRING)
+  private ContractType contractType;
+  /**
    * 매물 가격 정보.
    */
   @Embedded
@@ -43,7 +49,6 @@ public class PropertyInformation {
    */
   @Embedded
   private PropertyFloor propertyFloor;
-
   /**
    * 주차 가능 여부.
    */
@@ -56,7 +61,7 @@ public class PropertyInformation {
   /**
    * 준공일자.
    */
-  private LocalDate estDate;
+  private LocalDate completionDate;
 
   /**
    * 매물 정보 생성자.
@@ -64,19 +69,21 @@ public class PropertyInformation {
   @Builder
   public PropertyInformation(int area,
                              StructureType structureType,
+                             ContractType contractType,
                              PropertyPrice propertyPrice,
                              ResidentialType residentialType,
                              PropertyFloor propertyFloor,
                              boolean availableParking,
                              LocalDate moveInDate,
-                             LocalDate estDate) {
+                             LocalDate completionDate) {
     this.area = area;
     this.structureType = structureType;
+    this.contractType = contractType;
     this.propertyPrice = propertyPrice;
     this.residentialType = residentialType;
     this.propertyFloor = propertyFloor;
     this.availableParking = availableParking;
     this.moveInDate = moveInDate;
-    this.estDate = estDate;
+    this.completionDate = completionDate;
   }
 }

--- a/src/main/java/com/realestate/service/web/property/request/CreatePropertyRequest.java
+++ b/src/main/java/com/realestate/service/web/property/request/CreatePropertyRequest.java
@@ -7,6 +7,7 @@ import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.realestate.service.common.time.DatePattern;
+import com.realestate.service.property.constant.ContractType;
 import com.realestate.service.property.constant.ResidentialType;
 import com.realestate.service.property.constant.StructureType;
 import com.realestate.service.property.dto.CreatePropertyCommand;
@@ -47,6 +48,8 @@ public class CreatePropertyRequest {
     private int area;
     @NotNull(message = "매물 구조 타입은 필수 입력입니다.")
     private StructureType structureType;
+    @NotNull(message = "매물 계약 타입은 필수 입력입니다.")
+    private ContractType contractType;
     private Long sellPrice;
     private Long deposit;
     private Integer monthlyPrice;
@@ -60,7 +63,7 @@ public class CreatePropertyRequest {
     @JsonFormat(pattern = DatePattern.DEFAULT_DATE)
     private LocalDate moveInDate;
     @JsonFormat(pattern = DatePattern.DEFAULT_DATE)
-    private LocalDate estDate;
+    private LocalDate completionDate;
   }
 
 
@@ -74,6 +77,7 @@ public class CreatePropertyRequest {
         .content(content)
         .area(information.getArea())
         .structureType(information.getStructureType())
+        .contractType(information.getContractType())
         .sellPrice(information.getSellPrice())
         .deposit(information.getDeposit())
         .monthlyPrice(information.getMonthlyPrice())
@@ -83,7 +87,7 @@ public class CreatePropertyRequest {
         .topFloor(information.getTopFloor())
         .availableParking(information.getAvailableParking())
         .moveInDate(information.getMoveInDate())
-        .estDate(information.getEstDate())
+        .completionDate(information.getCompletionDate())
         .build();
 
     var addressCommand = CreatePropertyCommand

--- a/src/test/java/com/realestate/service/ContextLoadTest.java
+++ b/src/test/java/com/realestate/service/ContextLoadTest.java
@@ -4,11 +4,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-//@SpringBootTest
 @ActiveProfiles("test")
 @ExtendWith(SpringExtension.class)
 public class ContextLoadTest {

--- a/src/test/java/com/realestate/service/property/CreatePropertyServiceTest.java
+++ b/src/test/java/com/realestate/service/property/CreatePropertyServiceTest.java
@@ -90,7 +90,7 @@ class CreatePropertyServiceTest {
           .sellPrice(givenSellPrice)
           .monthlyPrice(givenMonthlyPrice)
           .residentialType(ResidentialType.APARTMENT)
-          .structureType(StructureType.TREE_ROOM)
+          .structureType(StructureType.THREE_ROOM)
           .contractType(ContractType.SALE)
           .floor(givenFloor)
           .topFloor(givenTopFloor)

--- a/src/test/java/com/realestate/service/property/CreatePropertyServiceTest.java
+++ b/src/test/java/com/realestate/service/property/CreatePropertyServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 
 import com.realestate.service.property.address.entity.PropertyAddressRepository;
+import com.realestate.service.property.constant.ContractType;
 import com.realestate.service.property.constant.ResidentialType;
 import com.realestate.service.property.constant.StructureType;
 import com.realestate.service.property.dto.CreatePropertyCommand;
@@ -83,13 +84,14 @@ class CreatePropertyServiceTest {
           .area(givenArea)
           .availableParking(true)
           .deposit(givenDeposit)
-          .estDate(LocalDate.now())
+          .completionDate(LocalDate.now())
           .moveInDate(LocalDate.now())
           .adminPrice(givenAdminPrice)
           .sellPrice(givenSellPrice)
           .monthlyPrice(givenMonthlyPrice)
           .residentialType(ResidentialType.APARTMENT)
           .structureType(StructureType.TREE_ROOM)
+          .contractType(ContractType.SALE)
           .floor(givenFloor)
           .topFloor(givenTopFloor)
           .build();

--- a/src/test/java/com/realestate/service/property/PropertyServiceHelper.java
+++ b/src/test/java/com/realestate/service/property/PropertyServiceHelper.java
@@ -2,12 +2,11 @@ package com.realestate.service.property;
 
 import static com.realestate.service.property.constant.ContractType.*;
 import static com.realestate.service.property.constant.ResidentialType.APARTMENT;
-import static com.realestate.service.property.constant.StructureType.TREE_ROOM;
+import static com.realestate.service.property.constant.StructureType.THREE_ROOM;
 
 import com.realestate.service.property.address.entity.PropertyAddress;
 import java.time.LocalDate;
 
-import com.realestate.service.property.constant.ContractType;
 import com.realestate.service.property.entity.Property;
 import com.realestate.service.property.entity.PropertyFloor;
 import com.realestate.service.property.entity.PropertyInformation;
@@ -62,7 +61,7 @@ public class PropertyServiceHelper {
         .propertyFloor(new PropertyFloor(givenFloor, givenTopFloor))
         .availableParking(true)
         .residentialType(APARTMENT)
-        .structureType(TREE_ROOM)
+        .structureType(THREE_ROOM)
         .contractType(SALE)
         .build();
 

--- a/src/test/java/com/realestate/service/property/PropertyServiceHelper.java
+++ b/src/test/java/com/realestate/service/property/PropertyServiceHelper.java
@@ -1,11 +1,13 @@
 package com.realestate.service.property;
 
+import static com.realestate.service.property.constant.ContractType.*;
 import static com.realestate.service.property.constant.ResidentialType.APARTMENT;
 import static com.realestate.service.property.constant.StructureType.TREE_ROOM;
 
 import com.realestate.service.property.address.entity.PropertyAddress;
 import java.time.LocalDate;
 
+import com.realestate.service.property.constant.ContractType;
 import com.realestate.service.property.entity.Property;
 import com.realestate.service.property.entity.PropertyFloor;
 import com.realestate.service.property.entity.PropertyInformation;
@@ -54,13 +56,14 @@ public class PropertyServiceHelper {
 
     var givenPropertyInformation = PropertyInformation.builder()
         .area(givenArea)
-        .estDate(LocalDate.now())
+        .completionDate(LocalDate.now())
         .moveInDate(LocalDate.now())
         .propertyPrice(givenPropertyPrice)
         .propertyFloor(new PropertyFloor(givenFloor, givenTopFloor))
         .availableParking(true)
         .residentialType(APARTMENT)
         .structureType(TREE_ROOM)
+        .contractType(SALE)
         .build();
 
     return Property.builder()

--- a/src/test/java/com/realestate/service/property/entity/PropertyRepositoryTest.java
+++ b/src/test/java/com/realestate/service/property/entity/PropertyRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.realestate.service.property.entity;
 
+import static com.realestate.service.property.constant.ContractType.*;
 import static com.realestate.service.property.constant.ResidentialType.APARTMENT;
 import static com.realestate.service.property.constant.StructureType.TREE_ROOM;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -7,6 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.realestate.service.config.TestConfig;
 import com.realestate.service.property.address.entity.PropertyAddress;
 import com.realestate.service.property.address.entity.PropertyAddressRepository;
+import com.realestate.service.property.constant.ContractType;
 import com.realestate.service.property.image.constant.MimeType;
 import com.realestate.service.property.image.entity.PropertyImage;
 import com.realestate.service.property.image.entity.PropertyImageRepository;
@@ -88,13 +90,14 @@ class PropertyRepositoryTest {
 
       var givenPropertyInformation = PropertyInformation.builder()
           .area(givenArea)
-          .estDate(LocalDate.now())
+          .completionDate(LocalDate.now())
           .moveInDate(LocalDate.now())
           .propertyPrice(givenPropertyPrice)
           .propertyFloor(new PropertyFloor(givenFloor, givenTopFloor))
           .availableParking(true)
           .residentialType(APARTMENT)
           .structureType(TREE_ROOM)
+          .contractType(LARGE_DEPOSIT)
           .build();
 
       return Property.builder()
@@ -124,6 +127,7 @@ class PropertyRepositoryTest {
         assertThat(savedProperty.getContent()).isEqualTo(givenContent);
         assertThat(savedProperty.getCreatedDateTime()).isBefore(LocalDateTime.now());
         assertThat(savedProperty.getPropertyInformation().getArea()).isEqualTo(givenArea);
+        assertThat(savedProperty.getPropertyInformation().getContractType()).isEqualTo(LARGE_DEPOSIT);
         assertThat(savedProperty.getPropertyInformation().getPropertyPrice().getSellPrice()).isEqualTo(givenSellPrice);
         assertThat(savedProperty.getPropertyInformation().getPropertyFloor().getTopFloor()).isEqualTo(givenTopFloor);
       }

--- a/src/test/java/com/realestate/service/property/entity/PropertyRepositoryTest.java
+++ b/src/test/java/com/realestate/service/property/entity/PropertyRepositoryTest.java
@@ -2,13 +2,12 @@ package com.realestate.service.property.entity;
 
 import static com.realestate.service.property.constant.ContractType.*;
 import static com.realestate.service.property.constant.ResidentialType.APARTMENT;
-import static com.realestate.service.property.constant.StructureType.TREE_ROOM;
+import static com.realestate.service.property.constant.StructureType.THREE_ROOM;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.realestate.service.config.TestConfig;
 import com.realestate.service.property.address.entity.PropertyAddress;
 import com.realestate.service.property.address.entity.PropertyAddressRepository;
-import com.realestate.service.property.constant.ContractType;
 import com.realestate.service.property.image.constant.MimeType;
 import com.realestate.service.property.image.entity.PropertyImage;
 import com.realestate.service.property.image.entity.PropertyImageRepository;
@@ -96,8 +95,8 @@ class PropertyRepositoryTest {
           .propertyFloor(new PropertyFloor(givenFloor, givenTopFloor))
           .availableParking(true)
           .residentialType(APARTMENT)
-          .structureType(TREE_ROOM)
-          .contractType(LARGE_DEPOSIT)
+          .structureType(THREE_ROOM)
+          .contractType(JEONSE)
           .build();
 
       return Property.builder()
@@ -127,7 +126,7 @@ class PropertyRepositoryTest {
         assertThat(savedProperty.getContent()).isEqualTo(givenContent);
         assertThat(savedProperty.getCreatedDateTime()).isBefore(LocalDateTime.now());
         assertThat(savedProperty.getPropertyInformation().getArea()).isEqualTo(givenArea);
-        assertThat(savedProperty.getPropertyInformation().getContractType()).isEqualTo(LARGE_DEPOSIT);
+        assertThat(savedProperty.getPropertyInformation().getContractType()).isEqualTo(JEONSE);
         assertThat(savedProperty.getPropertyInformation().getPropertyPrice().getSellPrice()).isEqualTo(givenSellPrice);
         assertThat(savedProperty.getPropertyInformation().getPropertyFloor().getTopFloor()).isEqualTo(givenTopFloor);
       }

--- a/src/test/java/com/realestate/service/web/property/PropertyMockHelper.java
+++ b/src/test/java/com/realestate/service/web/property/PropertyMockHelper.java
@@ -2,12 +2,11 @@ package com.realestate.service.web.property;
 
 import static com.realestate.service.property.constant.ContractType.*;
 import static com.realestate.service.property.constant.ResidentialType.APARTMENT;
-import static com.realestate.service.property.constant.StructureType.TREE_ROOM;
+import static com.realestate.service.property.constant.StructureType.THREE_ROOM;
 import static org.springframework.util.ResourceUtils.CLASSPATH_URL_PREFIX;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.realestate.service.property.constant.ContractType;
 import com.realestate.service.property.entity.Property;
 import com.realestate.service.property.entity.PropertyFloor;
 import com.realestate.service.property.entity.PropertyInformation;
@@ -70,8 +69,8 @@ public class PropertyMockHelper {
         .propertyFloor(new PropertyFloor(givenFloor, givenTopFloor))
         .availableParking(true)
         .residentialType(APARTMENT)
-        .structureType(TREE_ROOM)
-        .contractType(LARGE_DEPOSIT)
+        .structureType(THREE_ROOM)
+        .contractType(JEONSE)
         .build();
 
     return Property.builder()

--- a/src/test/java/com/realestate/service/web/property/PropertyMockHelper.java
+++ b/src/test/java/com/realestate/service/web/property/PropertyMockHelper.java
@@ -1,11 +1,13 @@
 package com.realestate.service.web.property;
 
+import static com.realestate.service.property.constant.ContractType.*;
 import static com.realestate.service.property.constant.ResidentialType.APARTMENT;
 import static com.realestate.service.property.constant.StructureType.TREE_ROOM;
 import static org.springframework.util.ResourceUtils.CLASSPATH_URL_PREFIX;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.realestate.service.property.constant.ContractType;
 import com.realestate.service.property.entity.Property;
 import com.realestate.service.property.entity.PropertyFloor;
 import com.realestate.service.property.entity.PropertyInformation;
@@ -62,13 +64,14 @@ public class PropertyMockHelper {
 
     var givenPropertyInformation = PropertyInformation.builder()
         .area(givenArea)
-        .estDate(LocalDate.now())
+        .completionDate(LocalDate.now())
         .moveInDate(LocalDate.now())
         .propertyPrice(givenPropertyPrice)
         .propertyFloor(new PropertyFloor(givenFloor, givenTopFloor))
         .availableParking(true)
         .residentialType(APARTMENT)
         .structureType(TREE_ROOM)
+        .contractType(LARGE_DEPOSIT)
         .build();
 
     return Property.builder()

--- a/src/test/resources/mock/property/create_property_request.json
+++ b/src/test/resources/mock/property/create_property_request.json
@@ -4,7 +4,7 @@
   "information" : {
     "area": 1234,
     "structureType": "ONE_ROOM",
-    "contractType": "LARGE_DEPOSIT",
+    "contractType": "JEONSE",
     "sellPrice": 300000000,
     "deposit": 10000000,
     "monthlyPrice" : 250000000,

--- a/src/test/resources/mock/property/create_property_request.json
+++ b/src/test/resources/mock/property/create_property_request.json
@@ -4,6 +4,7 @@
   "information" : {
     "area": 1234,
     "structureType": "ONE_ROOM",
+    "contractType": "LARGE_DEPOSIT",
     "sellPrice": 300000000,
     "deposit": 10000000,
     "monthlyPrice" : 250000000,
@@ -13,7 +14,7 @@
     "topFloor" : 15,
     "availableParking" : true,
     "moveInDate" : "2021-10-25",
-    "estDate" : "2021-10-25"
+    "completionDate" : "2021-10-25"
   },
   "address" : {
     "city" : "서울",


### PR DESCRIPTION
## 개요 🧐

## 작업 사항 💻
- 계약 타입 ```enum```을 추가하고 매물 관련 클래스에 계약 타입 필드를 추가하였습니다.
- 매물의 준공일자 명칭을 ```estDate``` -> ```completionDate``` 로 변경하였습니다.

## 참고 문서 📘
-

## 체크 리스트 ✅

PR을 발행하기 이전에 아래의 항목을 확인해 주세요.

- [x] 작성된 코드에 대해 테스트 코드를 적절히 추가, 변경, 삭제 하였습니까?
    - 테스트 코드가 필요 없는 경우 간략히 설명해 주세요.
- [x] 모든 테스트 코드가 성공 하였습니까? (명령어 : `./gradlew test`)
- [ ] 코드 스타일 검사를 통과 하였습니까? (명령어 : `./gradlew checkstyle`)