### PR TITLE
매물 관련 restDoc 테스트의 컴포넌트 스캔 대상에서 webSecurityConfig를 제외하라

### DIFF
--- a/src/test/java/com/realestate/service/web/member/MemberRestDoc.java
+++ b/src/test/java/com/realestate/service/web/member/MemberRestDoc.java
@@ -19,27 +19,22 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.List;
-
 import com.realestate.service.config.WebSecurityConfig;
 import com.realestate.service.member.FindMemberUseCase;
-import com.realestate.service.user.jwt.JwtAuthenticationEntryPoint;
 import com.realestate.service.user.jwt.JwtRequestFilter;
-import com.realestate.service.user.jwt.JwtTokenUtil;
-import com.realestate.service.user.jwt.JwtUserDetailService;
-import com.realestate.service.user.service.PasswordEncoderService;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.payload.FieldDescriptor;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfiguration;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
@@ -50,7 +45,12 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 
 @DisplayName("회원 정보 v1")
 @ExtendWith({SpringExtension.class, RestDocumentationExtension.class})
-@WebMvcTest(MemberRestController.class)
+@WebMvcTest(controllers = MemberRestController.class, excludeFilters = {
+    @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
+        WebSecurityConfig.class,
+        JwtRequestFilter.class
+    })
+})
 @MockBean(JpaMetamodelMappingContext.class)
 @ActiveProfiles("test")
 public class MemberRestDoc {
@@ -61,30 +61,6 @@ public class MemberRestDoc {
 
   @MockBean
   FindMemberUseCase findMemberUseCase;
-
-  @MockBean
-  WebSecurityConfig webSecurityConfig;
-
-  @MockBean
-  JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
-
-  @MockBean
-  JwtTokenUtil jwtTokenUtil;
-
-  @MockBean
-  JwtUserDetailService jwtUserDetailService;
-
-  @MockBean
-  JwtRequestFilter jwtRequestFilter;
-
-  @MockBean
-  AuthenticationManager authenticationManager;
-
-  @MockBean
-  PasswordEncoderService passwordEncoderService;
-
-  @MockBean
-  WebSecurityConfiguration webSecurityConfiguration;
 
   @BeforeEach
   void setUp(WebApplicationContext webApplicationContext,

--- a/src/test/java/com/realestate/service/web/property/CreatePropertyRestDoc.java
+++ b/src/test/java/com/realestate/service/web/property/CreatePropertyRestDoc.java
@@ -9,9 +9,9 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
-import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
 import static org.springframework.restdocs.payload.PayloadDocumentation.beneathPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
@@ -20,16 +20,11 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.List;
-
 import com.realestate.service.config.WebSecurityConfig;
 import com.realestate.service.property.CreatePropertyUseCase;
-import com.realestate.service.user.jwt.JwtAuthenticationEntryPoint;
 import com.realestate.service.user.jwt.JwtRequestFilter;
-import com.realestate.service.user.jwt.JwtTokenUtil;
-import com.realestate.service.user.jwt.JwtUserDetailService;
-import com.realestate.service.user.service.PasswordEncoderService;
 import com.realestate.service.web.property.response.CreatePropertyResponse;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,12 +32,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.payload.FieldDescriptor;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfiguration;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -50,9 +45,14 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
-@DisplayName("매물 정보")
+@DisplayName("매물 등록 정보")
 @ExtendWith(RestDocumentationExtension.class)
-@WebMvcTest(CreatePropertyRestController.class)
+@WebMvcTest(controllers = CreatePropertyRestController.class, excludeFilters = {
+    @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
+        WebSecurityConfig.class,
+        JwtRequestFilter.class
+    })
+})
 @MockBean(JpaMetamodelMappingContext.class)
 @ActiveProfiles("test")
 public class CreatePropertyRestDoc {
@@ -63,30 +63,6 @@ public class CreatePropertyRestDoc {
 
   @MockBean
   CreatePropertyUseCase createPropertyUseCase;
-
-  @MockBean
-  WebSecurityConfig webSecurityConfig;
-
-  @MockBean
-  JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
-
-  @MockBean
-  JwtTokenUtil jwtTokenUtil;
-
-  @MockBean
-  JwtUserDetailService jwtUserDetailService;
-
-  @MockBean
-  JwtRequestFilter jwtRequestFilter;
-
-  @MockBean
-  AuthenticationManager authenticationManager;
-
-  @MockBean
-  PasswordEncoderService passwordEncoderService;
-
-  @MockBean
-  WebSecurityConfiguration webSecurityConfiguration;
 
   @BeforeEach
   void setUp(WebApplicationContext webApplicationContext,

--- a/src/test/java/com/realestate/service/web/property/DeletePropertyRestDoc.java
+++ b/src/test/java/com/realestate/service/web/property/DeletePropertyRestDoc.java
@@ -18,6 +18,8 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.realestate.service.config.WebSecurityConfig;
+import com.realestate.service.user.jwt.JwtRequestFilter;
 import java.util.List;
 
 import com.realestate.service.property.DeletePropertyUseCase;
@@ -29,6 +31,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
@@ -41,9 +45,14 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
-@DisplayName("매물 정보")
+@DisplayName("매물 삭제 정보")
 @ExtendWith(RestDocumentationExtension.class)
-@WebMvcTest(DeletePropertyRestController.class)
+@WebMvcTest(controllers = DeletePropertyRestController.class, excludeFilters = {
+    @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
+        WebSecurityConfig.class,
+        JwtRequestFilter.class
+    })
+})
 @MockBean(JpaMetamodelMappingContext.class)
 @ActiveProfiles("test")
 public class DeletePropertyRestDoc {

--- a/src/test/java/com/realestate/service/web/property/UpdatePropertyRestDoc.java
+++ b/src/test/java/com/realestate/service/web/property/UpdatePropertyRestDoc.java
@@ -21,7 +21,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.realestate.service.config.WebSecurityConfig;
 import com.realestate.service.property.UpdatePropertyUseCase;
+import com.realestate.service.user.jwt.JwtRequestFilter;
 import com.realestate.service.web.property.response.UpdatePropertyResponse;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,6 +33,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
@@ -42,9 +46,14 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
-@DisplayName("매물 정보")
+@DisplayName("매물 수정 정보")
 @ExtendWith(RestDocumentationExtension.class)
-@WebMvcTest(UpdatePropertyRestController.class)
+@WebMvcTest(controllers = UpdatePropertyRestController.class, excludeFilters = {
+    @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
+        WebSecurityConfig.class,
+        JwtRequestFilter.class
+    })
+})
 @MockBean(JpaMetamodelMappingContext.class)
 @ActiveProfiles("test")
 public class UpdatePropertyRestDoc {


### PR DESCRIPTION
## 개요 🧐

- ```jwt``` 기능이 추가되면서 매물 관련 ```restdoc``` 테스트가 ```jwt```관련 설정을 의존하게 되어 테스트가 실패하였습니다.
- 하지만 매물 관련 ```api``` 이미 검증된 사용자만 호출할 수 있기에 ```restDocs test```에 ```webSecurityConfig```를 컴포넌트 
  스캔 대상에서 제외하였습니다.

## 작업 사항 💻

- 매물 관련 ```restdoc test```의 컴포넌트 대상에서  ```jwt``` 관련 기능을 제외하였습니다.
- ```DisplayName```을 명확하게 변경하였습니다.

## 참고 문서 📘
-

## 체크 리스트 ✅

PR을 발행하기 이전에 아래의 항목을 확인해 주세요.

- [x] 작성된 코드에 대해 테스트 코드를 적절히 추가, 변경, 삭제 하였습니까?
    - 테스트 코드가 필요 없는 경우 간략히 설명해 주세요.
- [x] 모든 테스트 코드가 성공 하였습니까? (명령어 : `./gradlew test`)
![image](https://user-images.githubusercontent.com/47877273/155697320-adc483dd-c1a1-4573-9ea4-baaf380a84cc.png)
- [ ] 코드 스타일 검사를 통과 하였습니까? (명령어 : `./gradlew checkstyle`)